### PR TITLE
Fixing es5 react compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ new Metalsmith("./")
       before: "<!doctype html>\n",
       data: {
         some: "data", // you might be able to consume that as props in the template
-      }),
+      },
       reactRender: "renderToStaticMarkup" //you can use "renderToString" if you want
+    })
   )
   .build(err => {if (err) {throw err}})
 ```

--- a/src/__tests__/modules/classic.js
+++ b/src/__tests__/modules/classic.js
@@ -1,0 +1,8 @@
+var React = require("react") // eslint-disable-line
+
+module.exports = function(props) {
+  var content = React.createElement("div", { // eslint-disable-line
+    dangerouslySetInnerHTML: { __html: props.file.contents },
+  })
+  return React.createElement("div", null, [ "Hello", content ])
+}

--- a/src/__tests__/renderToStaticMarkup.js
+++ b/src/__tests__/renderToStaticMarkup.js
@@ -31,7 +31,11 @@ test.cb("renderToStaticMarkup", (t) => {
         "text\n",
         "should not wrap file content when doesn't match pattern"
       )
-
+      t.is(
+        files["4.md"].contents.toString(),
+        "<div>Hello<div>Classic Test\n</div></div>",
+        "should wrap file content with es5 react template"
+      )
       t.end()
     })
     .build(err => {

--- a/src/__tests__/src/4.md
+++ b/src/__tests__/src/4.md
@@ -1,0 +1,5 @@
+---
+title: classic-title
+template: classic
+---
+Classic Test

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,12 @@ export default (options) => {
     each(
       multimatch(Object.keys(files), options.pattern),
       (file, cb) => {
-        const template = metalsmith.path(path.join(
+        const templatePath = metalsmith.path(path.join(
           options.templatesPath,
           files[file].template || options.defaultTemplate
         ))
-        const reactClass = require(template).default
+        const template = require(templatePath)
+        const reactClass = template.default || template
         const Factory = React.createFactory(reactClass)
         const component = new Factory({
           ...metadata,


### PR DESCRIPTION
- Fixed README
- Added build task
- Fixed tests to work without babel-node
- ES5 React now compiles
- Fixes #2
